### PR TITLE
Simple solution using just the iFrames

### DIFF
--- a/ddb-dm-screen-B.user.js
+++ b/ddb-dm-screen-B.user.js
@@ -1,0 +1,29 @@
+// ==UserScript==
+// @name         ddb-dm-screen-B
+// @namespace    https://github.com/mivalsten/ddb-dm-screen
+// @version      1.0.0
+// @description  Poor man's DM screen for DDB campaigns
+// @author       You
+// @match        https://www.dndbeyond.com/campaigns/*
+// @grant        none
+// ==/UserScript==
+//
+var $ = window.jQuery;
+
+(function() {
+    $('.ddb-campaigns-character-card-footer-links-item-view').each(function(index, value) {
+        let node = $(this);
+
+        // Remove existing header info in preference of iFrame header
+        let card = node.closest('.ddb-campaigns-character-card');
+        card.find('.ddb-campaigns-character-card-header-upper-portrait').remove();
+        card.find('.ddb-campaigns-character-card-header-upper-character-info-primary').remove();
+        card.find('.ddb-campaigns-character-card-header-upper-character-info-secondary').first().remove();
+
+        //.ddb-campaigns-character-card-header padding 20px
+
+        if (!node.parents().hasClass('ddb-campaigns-detail-body-listing-inactive')) {
+            card.find('.ddb-campaigns-character-card-header').after(`<iframe src="${node.attr('href')}" style="width: 100%; height: 550px"></iframe>`);
+        }
+    });
+})();


### PR DESCRIPTION
I'm curious if you have considered a simple solution like this?  I've been using this on Mac Book, and really like it.

PROS:
- Only maintenance is when D&DB campaign page markup changes
- Any changes to D&DB character editor/viewer are picked up/available in DM Screen right away

CONS:
- There isn't much coding involved, so hobby/learning something new is more or less nil
- May not work on a tablet (or Phone, but why go there for a DM screen?)

Possible enhancements:
- I think I'd like to add some buttons outside the iFrames for the various options - Actions, Spells, Equipment, etc.  When using those buttons, make all character views transition to that same view.  That is, if I chose "Abilities", make all character tiles transition to the Abilities view.

Thoughts?